### PR TITLE
More compact display of list items and choice lists

### DIFF
--- a/src/default.css
+++ b/src/default.css
@@ -465,3 +465,43 @@ div#versions td.no-versions {
   border-radius: .5rem;
   padding: 1rem;
 }
+/* --- List question: table view (< 6 sub-questions) --- */
+.answer-items-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.5em 0 1em 0;
+  font-size: 0.95em;
+}
+
+.answer-items-table thead tr {
+  background-color: #f0f0f0;
+}
+
+.answer-items-table th {
+  text-align: left;
+  padding: 0.4em 0.75em;
+  border: 1px solid #ddd;
+  font-weight: 600;
+  color: #333;
+}
+
+.answer-items-table td {
+  padding: 0.4em 0.75em;
+  border: 1px solid #ddd;
+  vertical-align: top;
+}
+
+.answer-items-table tbody tr:nth-child(even) {
+  background-color: #fafafa;
+}
+
+.answer-items-table .item-index-col {
+  width: 2em;
+  text-align: center;
+  color: #888;
+  font-size: 0.85em;
+}
+
+.answer-items-table .no-answer {
+  color: #aaa;
+}

--- a/src/default.html.j2
+++ b/src/default.html.j2
@@ -113,18 +113,79 @@
   </div>
 {%- endmacro -%}
 {%- macro renderAnswerList(question, reply, path, humanIdentifier) -%}
-  <div class="answer-block answer-items" id="{{path}}" data-path="{{path}}" data-type="answer">
-    <h4>Answers</h4>
-    {% set itemPathPrefix = path ~ "." %}
-    {% set hiPrefix = humanIdentifier ~ "." %}
+<div class="answer-block answer-items" id="{{path}}" data-path="{{path}}" data-type="answer">
+  <h4>Answers</h4>
+  {% set itemPathPrefix = path ~ "." %}
+  {% set hiPrefix = humanIdentifier ~ "." %}
+  {% if question.followups|length > 0 and question.followups|length < 6 %}
+    {# --- TABLE VIEW: fewer than 6 sub-questions --- #}
+    <table class="answer-items-table">
+      <thead>
+        <tr>
+          <th class="item-index-col">#</th>
+          {% for fq in question.followups %}
+          <th>{{ fq.title }}</th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for itemUuid in reply.items %}
+          {% set itemPath = itemPathPrefix ~ itemUuid %}
+          <tr id="item-{{ question.uuid }}-{{itemUuid}}" data-path="{{itemPath}}">
+            <td class="item-index-col">{{ loop.index }}</td>
+            {% for fq in question.followups %}
+              {% set fqPath = itemPath ~ "." ~ fq.uuid %}
+              {% set fqReply = fq.replies.get(fqPath) %}
+              <td>
+                {% if fqReply and fqReply.value %}
+                  {% if fq is of_type("ValueQuestion") and fqReply is of_type("StringReply") %}
+                    <span>{{ fqReply.markdown_plain }}</span>
+                  {% elif fqReply.is_integration or fqReply.is_legacy_integration %}
+                    <span>{{ fqReply.value|markdown }}</span>
+                  {% elif fq is of_type("OptionsQuestion") and fqReply is of_type("AnswerReply") %}
+                    <span>{{ fqReply.answer.label }}</span>
+                  {% elif fq is of_type("MultiChoiceQuestion") and fqReply is of_type("MultiChoiceReply") %}
+                    <span>
+                      {%- set chosen = [] -%}
+                      {%- for choice in fq.choices -%}
+                        {%- if choice in fqReply.choices -%}{%- do chosen.append(choice.label) -%}{%- endif -%}
+                      {%- endfor -%}
+                      {{ chosen | join(", ") }}
+                    </span>
+                  {% elif fq is of_type("ItemSelectQuestion") and fqReply is of_type("ItemSelectReply") %}
+                    <a href="#item-{{ fq.list_question_uuid }}-{{ fqReply.item_uuid }}">{{ fqReply.item_title }}</a>
+                  {% elif fq is of_type("FileQuestion") and fqReply is of_type("FileReply") %}
+                    {% if fqReply.file %}
+                      <a href="{{ fqReply.file.download_url }}" target="_blank">{{ fqReply.file.name }}</a>
+                    {% else %}
+                      <span class="no-answer">—</span>
+                    {% endif %}
+                  {% else %}
+                    <span>{{ fqReply.value }}</span>
+                  {% endif %}
+                {% else %}
+                  <span class="no-answer">—</span>
+                {% endif %}
+              </td>
+            {% endfor %}
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="{{ question.followups|length + 1 }}" class="no-answer">No answer items</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    {# --- LIST VIEW: 6+ sub-questions or no followups --- #}
     {% for itemUuid in reply.items %}
       {% set itemPath = itemPathPrefix ~ itemUuid %}
       {% set itemHumanIdentifier = hiPrefix ~ (loop.index - 1)|of_alphabet %}
       <div class="answer-item" id="item-{{ question.uuid }}-{{itemUuid}}" data-path="{{itemPath}}">
         <div class="followups">
-          {% for question in question.followups %}
+          {% for subQuestion in question.followups %}
             {% set x = loop.index %}
-            {{ renderQuestion(question, itemPath, itemHumanIdentifier ~ "." ~ x) }}
+            {{ renderQuestion(subQuestion, itemPath, itemHumanIdentifier ~ "." ~ x) }}
           {% else %}
             No follow up questions
           {% endfor %}
@@ -133,26 +194,25 @@
     {% else %}
       No answer items
     {% endfor %}
-  </div>
+  {% endif %}
+</div>
 {%- endmacro -%}
 {%- macro renderAnswerChoiceList(question, reply, path, humanIdentifier) -%}
-  <div class="answer-block answer-items" id="{{path}}" data-path="{{path}}" data-type="answer">
-    <div class="choices-list">
-    {% for choice in question.choices %}
-      {%- if choice in reply.choices %}
-        <div class="choice choice-selected">
-          <svg aria-hidden="true" focusable="false" data-prefix="far" data-icon="check-square" class="svg-inline--fa fa-check-square fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M400 32H48C21.49 32 0 53.49 0 80v352c0 26.51 21.49 48 48 48h352c26.51 0 48-21.49 48-48V80c0-26.51-21.49-48-48-48zm0 400H48V80h352v352zm-35.864-241.724L191.547 361.48c-4.705 4.667-12.303 4.637-16.97-.068l-90.781-91.516c-4.667-4.705-4.637-12.303.069-16.971l22.719-22.536c4.705-4.667 12.303-4.637 16.97.069l59.792 60.277 141.352-140.216c4.705-4.667 12.303-4.637 16.97.068l22.536 22.718c4.667 4.706 4.637 12.304-.068 16.971z"></path></svg>
-          {{ choice.label }}
-        </div>
-      {%- else %}
-        <div class="choice choice-unselected">
-          <svg aria-hidden="true" focusable="false" data-prefix="far" data-icon="square" class="svg-inline--fa fa-square fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zm-6 400H54c-3.3 0-6-2.7-6-6V86c0-3.3 2.7-6 6-6h340c3.3 0 6 2.7 6 6v340c0 3.3-2.7 6-6 6z"></path></svg>
-          {{ choice.label }}
-        </div>
-      {%- endif %}
-    {% endfor %}
-    </div>
-  </div>
+<div class="answer-block answer-items" id="{{path}}" data-path="{{path}}" data-type="answer">
+  <p class="answer">
+    {%- set chosen = [] -%}
+    {%- for choice in question.choices -%}
+      {%- if choice in reply.choices -%}
+        {%- do chosen.append(choice.label) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {% if chosen|length > 0 %}
+      <span>{{ chosen | join(", ") }}</span>
+    {% else %}
+      <span class="no-answer">No choices selected</span>
+    {% endif %}
+  </p>
+</div>
 {%- endmacro -%}
 {%- macro renderAnswerItemSelect(question, reply, path, humanIdentifier) -%}
   <div class="answer-block answer-select" id="{{path}}" data-path="{{path}}" data-type="answer">

--- a/src/default.md.j2
+++ b/src/default.md.j2
@@ -68,16 +68,17 @@
 {%- set path = path ~ "." ~ answer.uuid -%}
 {%- set humanIdentifier = humanIdentifier ~ "." ~ hi|of_alphabet -%}
 ✔️ {{ hi|of_alphabet }}. {{answer.label}}
-{% if answer.advice -%}
+{% if answer.advice %}
+
 💡 {{answer.advice}}
-{%- endif -%}
-{%- if answer.followups|length > 0 -%}
-{%- set hiPrefix = humanIdentifier ~ "." -%}
-{%- for question in answer.followups -%}
-{%- set x = loop.index -%}
-{{ renderQuestion(question, path, hiPrefix ~ x) }}
-{%- endfor -%}
-{%- endif -%}
+{% endif %}
+{% if answer.followups|length > 0 %}
+{% set hiPrefix = humanIdentifier ~ "." %}
+{% for subQuestion in answer.followups %}
+{% set x = loop.index %}
+{{ renderQuestion(subQuestion, path, hiPrefix ~ x) }}
+{% endfor %}
+{% endif %}
 {%- endmacro -%}
 {%- macro renderAnswerList(question, reply, path, humanIdentifier) -%}
 {% set itemPathPrefix = path ~ "." %}
@@ -136,36 +137,41 @@
 {{- renderExperts(question) -}}
 {%- endmacro -%}
 {%- macro renderQuestionReply(question, path, humanIdentifier) -%}
-{%- set reply = question.replies.get(path) -%}
-{%- if reply and reply.value -%}
-{%- if question is of_type("ValueQuestion") and reply is of_type("StringReply") -%}
+{% set reply = question.replies.get(path) %}
+{% if reply and reply.value %}
+{% if question is of_type("ValueQuestion") and reply is of_type("StringReply") %}
 {{ renderStringValue(question, reply, path, humanIdentifier) }}
-{%- elif question is of_type("OptionsQuestion") and reply is of_type("AnswerReply") -%}
+{% elif question is of_type("OptionsQuestion") and reply is of_type("AnswerReply") %}
 {{ renderAnswerOption(question, reply, path, humanIdentifier) }}
-{%- elif question is of_type("ListQuestion") and reply is of_type("ItemListReply") -%}
+{% elif question is of_type("ListQuestion") and reply is of_type("ItemListReply") %}
 {{ renderAnswerList(question, reply, path, humanIdentifier) }}
-{%- elif question is of_type("IntegrationQuestion") and reply is of_type("IntegrationReply") -%}
+{% elif question is of_type("IntegrationQuestion") and reply is of_type("IntegrationReply") %}
 {{ renderIntegrationValue(question, reply, path, humanIdentifier) }}
-{%- elif question is of_type("MultiChoiceQuestion") and reply is of_type("MultiChoiceReply") -%}
+{% elif question is of_type("MultiChoiceQuestion") and reply is of_type("MultiChoiceReply") %}
 {{ renderAnswerChoiceList(question, reply, path, humanIdentifier) }}
 {% elif question is of_type("ItemSelectQuestion") and reply is of_type("ItemSelectReply") %}
 {{ renderAnswerItemSelect(question, reply, path, humanIdentifier) }}
 {% elif question is of_type("FileQuestion") and reply is of_type("FileReply") %}
 {{ renderAnswerFile(question, reply, path, humanIdentifier) }}
-{%- endif -%}
-{%- else %}
+{% endif %}
+{% else %}
+
 ❗ *This question has not been answered yet!*
-{%- endif -%}
+{% endif %}
 {%- endmacro -%}
 {%- macro renderQuestion(question, path, humanIdentifier) -%}
-{%- set path = path ~ "." ~ question.uuid %}
+{% set path = path ~ "." ~ question.uuid %}
+
 #### {{humanIdentifier}} {{question.title}}
-{{- renderTags(question) -}}
-{{- renderQuestionExtras(question) -}}
-{%- if question.text %}
+
+{{ renderTags(question) }}
+{{ renderQuestionExtras(question) }}
+{% if question.text %}
 > {{ question.text.replace("\n", "\n> ") }}
-{%- endif %}
+
+{% endif %}
 {{ renderQuestionReply(question, path, humanIdentifier) }}
+
 {%- endmacro -%}
 {#- ------------------------------------------------------------------------------------ -#}
 {#-  CHAPTER MACROS                                                                      -#}

--- a/src/default.md.j2
+++ b/src/default.md.j2
@@ -80,29 +80,42 @@
 {%- endif -%}
 {%- endmacro -%}
 {%- macro renderAnswerList(question, reply, path, humanIdentifier) -%}
-{%- set itemPathPrefix = path ~ "." -%}
-{%- set hiPrefix = humanIdentifier ~ "." -%}
-{%- for i in reply.items -%}
-{%- set itemPath = itemPathPrefix ~ i -%}
-{%- set itemHumanIdentifier = hiPrefix ~ (loop.index - 1)|of_alphabet -%}
-{%- for question in question.followups -%}
-{%- set x = loop.index -%}
-{{ renderQuestion(question, itemPath, itemHumanIdentifier ~ "." ~ x) }}
-{%- else -%}
-*No follow up questions*
-{%- endfor -%}
-{%- else %}
+{% set itemPathPrefix = path ~ "." %}
+{% set hiPrefix = humanIdentifier ~ "." %}
+{% if question.followups|length > 0 and question.followups|length < 6 %}
+| # | {% for fq in question.followups %}{{ fq.title }} | {% endfor %}
+
+| --- | {% for fq in question.followups %}--- | {% endfor %}
+
+{% for itemUuid in reply.items %}
+{% set itemPath = itemPathPrefix ~ itemUuid %}
+| {{ loop.index }} | {% for fq in question.followups %}{% set fqPath = itemPath ~ "." ~ fq.uuid %}{% set fqReply = fq.replies.get(fqPath) %}{% if fqReply and fqReply.value %}{% if fq is of_type("ValueQuestion") and fqReply is of_type("StringReply") %}{{ fqReply.markdown_plain | replace("\n", " ") }}{% elif fq is of_type("OptionsQuestion") and fqReply is of_type("AnswerReply") %}{{ fqReply.answer.label }}{% elif fq is of_type("MultiChoiceQuestion") and fqReply is of_type("MultiChoiceReply") %}{%- set chosen = [] -%}{%- for choice in fq.choices -%}{%- if choice in fqReply.choices -%}{%- do chosen.append(choice.label) -%}{%- endif -%}{%- endfor -%}{{ chosen | join(", ") }}{% elif fqReply.is_integration or fqReply.is_legacy_integration %}{{ fqReply.value | replace("\n", " ") }}{% else %}{{ fqReply.value | replace("\n", " ") }}{% endif %}{% else %}—{% endif %} | {% endfor %}
+
+{% else %}
 *No answer items*
-{%- endfor -%}
+{% endfor %}
+{% else %}
+{% for itemUuid in reply.items %}
+{% set itemPath = itemPathPrefix ~ itemUuid %}
+{% set itemHumanIdentifier = hiPrefix ~ (loop.index - 1)|of_alphabet %}
+**Item {{ loop.index }}**
+
+{% for subQuestion in question.followups %}
+{{ renderQuestion(subQuestion, itemPath, itemHumanIdentifier ~ "." ~ loop.index) }}
+{% else %}
+*No follow up questions*
+{% endfor %}
+{% else %}
+*No answer items*
+{% endfor %}
+{% endif %}
 {%- endmacro -%}
 {%- macro renderAnswerChoiceList(question, reply, path, humanIdentifier) -%}
+{%- set chosen = [] -%}
 {%- for choice in question.choices -%}
-{%- if choice in reply.choices %}
-* ✔️ {{ choice.label }}
-{%- else %}
-* ❌ {{ choice.label }}
-{%- endif %}
+  {%- if choice in reply.choices -%}{%- do chosen.append(choice.label) -%}{%- endif -%}
 {%- endfor -%}
+{% if chosen|length > 0 %}{{ chosen | join(", ") }}{% else %}*No choices selected*{% endif %}
 {%- endmacro -%}
 {%- macro renderAnswerItemSelect(question, reply, path, humanIdentifier) -%}
 ✔️ {{ reply.item_title }}

--- a/src/default.tex.j2
+++ b/src/default.tex.j2
@@ -13,7 +13,10 @@
     \end{itemize}
   {%- else %}
     \begin{itemize}
-      \item[\CheckmarkBold] {{ reply.markdown_plain }}
+      \item[\CheckmarkBold]
+      \begin{markdown}
+      {{ reply.markdown_plain | regex_replace('!\[[^\]]*\]\([^\)]*\)', '') | trim }}
+      \end{markdown}
     \end{itemize}
   {%- endif %}
 {% else %}
@@ -58,7 +61,7 @@
 {% set hiPrefix = humanIdentifier ~ "." %}
 {% if question.followups|length > 0 and question.followups|length < 6 %}
 \begin{table}[h]
-\begin{tabular}{| l |{% for fq in question.followups %} p{{% if question.followups|length == 1 %}0.8{% elif question.followups|length == 2 %}0.38{% elif question.followups|length == 3 %}0.24{% elif question.followups|length == 4 %}0.17{% else %}0.13{% endif %}\textwidth} |{% endfor %}}
+\begin{tabular}{| l |{% for fq in question.followups %} p{{ "{" }}{%- if question.followups|length == 1 %}0.8{%- elif question.followups|length == 2 %}0.38{%- elif question.followups|length == 3 %}0.24{%- elif question.followups|length == 4 %}0.17{%- else %}0.13{%- endif %}\textwidth} |{% endfor %}}
 \hline
 \textbf{\#} & {% for fq in question.followups %}\textbf{ {{- fq.title | replace("_","\_") | replace("&","\&") | replace("%","\%") | replace("#","\#") -}} }{% if not loop.last %} & {% endif %}{% endfor %} \\
 \hline
@@ -144,16 +147,6 @@ No answer items
   {%- set experts = question.experts -%}
   {%- if resourcePageReferences|length > 0 or urlReferences|length > 0 or tags|length > 0 or experts|length > 0 %}
 \begin{itemize}
-  {%- if tags|length > 0 %}
-  \item \textit{Tags}: {% for tag in tags %}{% set color = tag.color[1:] if tag.color[0] == "#" else tag.color %}\setulcolor{{ "{" }}{{color}}{{ "}" }}\ul{{ "{" }}{{tag.name}}{{ "}" }}{% if not loop.last%}, {% endif %}{% endfor %}
-  {% endif %}
-  {%- if resourcePageReferences|length > 0 %}
-  \item \textit{Resource Pages}: {% for reference in resourcePageReferences -%}
-  {%- if reference.resource_page_uuid and reference.resource_page and reference.resource_page.collection -%}
-    {%- set resourcePageLink = dc.config.client_url ~ '/knowledge-models/' ~ dc.pkg.id ~ '/resource-pages/' ~ reference.resource_page.uuid -%}
-    \href{{ "{" }}{{ resourcePageLink }}{{ "}" }}{{ "{" }}{{ reference.resource_page.collection.title }} - {{ reference.resource_page.title }}{{ "}" }}
-    {%- if not loop.last -%}, {% endif -%}{%- endif -%}{%- endfor -%}
-  {%- endif -%}
   {%- if urlReferences|length > 0 %}
   \item \textit{External Links}: {% for reference in urlReferences -%}
     \href{{ "{" }}{{ reference.url }}{{ "}" }}{{ "{" }}{{ reference.label }}{{ "}" }}
@@ -365,7 +358,5 @@ No answer items
 {% endfor %}
 
 {% endfor %}
-
-</section>
 
 \end{document}

--- a/src/default.tex.j2
+++ b/src/default.tex.j2
@@ -54,36 +54,43 @@
 {%- endif -%}
 {%- endmacro -%}
 {%- macro renderAnswerList(question, reply, path, humanIdentifier) -%}
-{%- set itemPathPrefix = path ~ "." -%}
-{%- set hiPrefix = humanIdentifier ~ "." -%}
-\begin{itemize}
-  \item[\ArrowBoldDownRight] Answered with {{reply.items|length}} item{% if reply.items|length > 1 %}s{% endif %} as follows.
-\end{itemize}
-{%- for i in reply.items -%}
-{%- set itemPath = itemPathPrefix ~ i -%}
-{%- set itemHumanIdentifier = hiPrefix ~ (loop.index - 1)|of_alphabet -%}
-% Answer item: {{itemPath}}
-
-{%- for question in question.followups -%}
-  {%- set x = loop.index -%}
-{{ renderQuestion(question, itemPath, itemHumanIdentifier ~ "." ~ x, False) }}
-{% else -%}
-  \textit{No follow up questions}
+{% set itemPathPrefix = path ~ "." %}
+{% set hiPrefix = humanIdentifier ~ "." %}
+{% if question.followups|length > 0 and question.followups|length < 6 %}
+\begin{table}[h]
+\begin{tabular}{| l |{% for fq in question.followups %} p{{% if question.followups|length == 1 %}0.8{% elif question.followups|length == 2 %}0.38{% elif question.followups|length == 3 %}0.24{% elif question.followups|length == 4 %}0.17{% else %}0.13{% endif %}\textwidth} |{% endfor %}}
+\hline
+\textbf{\#} & {% for fq in question.followups %}\textbf{ {{- fq.title | replace("_","\_") | replace("&","\&") | replace("%","\%") | replace("#","\#") -}} }{% if not loop.last %} & {% endif %}{% endfor %} \\
+\hline
+{% for itemUuid in reply.items %}
+{% set itemPath = itemPathPrefix ~ itemUuid %}
+{{ loop.index }} & {% for fq in question.followups %}{% set fqPath = itemPath ~ "." ~ fq.uuid %}{% set fqReply = fq.replies.get(fqPath) %}{% if fqReply and fqReply.value %}{% if fq is of_type("ValueQuestion") and fqReply is of_type("StringReply") %}{{ fqReply.markdown_plain | replace("_","\_") | replace("&","\&") | replace("%","\%") | replace("#","\#") | replace("\n"," ") }}{% elif fq is of_type("OptionsQuestion") and fqReply is of_type("AnswerReply") %}{{ fqReply.answer.label | replace("_","\_") | replace("&","\&") }}{% elif fq is of_type("MultiChoiceQuestion") and fqReply is of_type("MultiChoiceReply") %}{%- set chosen = [] -%}{%- for choice in fq.choices -%}{%- if choice in fqReply.choices -%}{%- do chosen.append(choice.label) -%}{%- endif -%}{%- endfor -%}{{ chosen | join(", ") | replace("_","\_") | replace("&","\&") }}{% else %}{{ fqReply.value | replace("_","\_") | replace("&","\&") | replace("%","\%") | replace("\n"," ") }}{% endif %}{% else %}---{% endif %}{% if not loop.last %} & {% endif %}{% endfor %} \\
+\hline
+{% else %}
+\textit{No answer items}
 {% endfor %}
+\end{tabular}
+\end{table}
+{% else %}
+{% for itemUuid in reply.items %}
+{% set itemPath = itemPathPrefix ~ itemUuid %}
+{% set itemHumanIdentifier = hiPrefix ~ (loop.index - 1)|of_alphabet %}
+{% for subQuestion in question.followups %}
+{{ renderQuestion(subQuestion, itemPath, itemHumanIdentifier ~ "." ~ loop.index) }}
+{% else %}
+No follow up questions
 {% endfor %}
+{% else %}
+No answer items
+{% endfor %}
+{% endif %}
 {%- endmacro -%}
 {%- macro renderAnswerChoiceList(question, reply, path, humanIdentifier) -%}
-{%- if question.choices|length > 0 -%}
-\begin{itemize}
+{%- set chosen = [] -%}
 {%- for choice in question.choices -%}
-{%- if choice in reply.choices %}
-  \item[\CheckmarkBold] {{ choice.label }}
-{%- else %}
-  \item[\XSolidBrush] {{ choice.label }}
-{%- endif -%}
-{%- endfor %}
-\end{itemize}
-{%- endif %}
+  {%- if choice in reply.choices -%}{%- do chosen.append(choice.label) -%}{%- endif -%}
+{%- endfor -%}
+{% if chosen|length > 0 %}{{ chosen | join(", ") }}{% else %}\textit{No choices selected}{% endif %}
 {%- endmacro -%}
 {%- macro renderAnswerItemSelect(question, reply, path, humanIdentifier) -%}
 \begin{itemize}

--- a/src/for-word.html.j2
+++ b/src/for-word.html.j2
@@ -108,40 +108,106 @@
   </div>
 {%- endmacro -%}
 {%- macro renderAnswerList(question, reply, path, humanIdentifier) -%}
-  <div>
-    <h4>Answers ({{reply.items|length}} items)</h4>
-    {% set itemPathPrefix = path ~ "." %}
-    {% set hiPrefix = humanIdentifier ~ "." %}
-    {% for i in reply.items %}
-      {% set itemPath = itemPathPrefix ~ i %}
+<div class="answer-block answer-items" id="{{path}}" data-path="{{path}}" data-type="answer">
+  <h4>Answers</h4>
+  {% set itemPathPrefix = path ~ "." %}
+  {% set hiPrefix = humanIdentifier ~ "." %}
+  {% if question.followups|length > 0 and question.followups|length < 6 %}
+    {# --- TABLE VIEW: fewer than 6 sub-questions --- #}
+    <table class="answer-items-table">
+      <thead>
+        <tr>
+          <th class="item-index-col">#</th>
+          {% for fq in question.followups %}
+          <th>{{ fq.title }}</th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for itemUuid in reply.items %}
+          {% set itemPath = itemPathPrefix ~ itemUuid %}
+          <tr id="item-{{ question.uuid }}-{{itemUuid}}" data-path="{{itemPath}}">
+            <td class="item-index-col">{{ loop.index }}</td>
+            {% for fq in question.followups %}
+              {% set fqPath = itemPath ~ "." ~ fq.uuid %}
+              {% set fqReply = fq.replies.get(fqPath) %}
+              <td>
+                {% if fqReply and fqReply.value %}
+                  {% if fq is of_type("ValueQuestion") and fqReply is of_type("StringReply") %}
+                    <span>{{ fqReply.markdown_plain }}</span>
+                  {% elif fqReply.is_integration or fqReply.is_legacy_integration %}
+                    <span>{{ fqReply.value|markdown }}</span>
+                  {% elif fq is of_type("OptionsQuestion") and fqReply is of_type("AnswerReply") %}
+                    <span>{{ fqReply.answer.label }}</span>
+                  {% elif fq is of_type("MultiChoiceQuestion") and fqReply is of_type("MultiChoiceReply") %}
+                    <span>
+                      {%- set chosen = [] -%}
+                      {%- for choice in fq.choices -%}
+                        {%- if choice in fqReply.choices -%}{%- do chosen.append(choice.label) -%}{%- endif -%}
+                      {%- endfor -%}
+                      {{ chosen | join(", ") }}
+                    </span>
+                  {% elif fq is of_type("ItemSelectQuestion") and fqReply is of_type("ItemSelectReply") %}
+                    <a href="#item-{{ fq.list_question_uuid }}-{{ fqReply.item_uuid }}">{{ fqReply.item_title }}</a>
+                  {% elif fq is of_type("FileQuestion") and fqReply is of_type("FileReply") %}
+                    {% if fqReply.file %}
+                      <a href="{{ fqReply.file.download_url }}" target="_blank">{{ fqReply.file.name }}</a>
+                    {% else %}
+                      <span class="no-answer">—</span>
+                    {% endif %}
+                  {% else %}
+                    <span>{{ fqReply.value }}</span>
+                  {% endif %}
+                {% else %}
+                  <span class="no-answer">—</span>
+                {% endif %}
+              </td>
+            {% endfor %}
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="{{ question.followups|length + 1 }}" class="no-answer">No answer items</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    {# --- LIST VIEW: 6+ sub-questions or no followups --- #}
+    {% for itemUuid in reply.items %}
+      {% set itemPath = itemPathPrefix ~ itemUuid %}
       {% set itemHumanIdentifier = hiPrefix ~ (loop.index - 1)|of_alphabet %}
-      <div class="answer-item" id="{{itemPath}}">
+      <div class="answer-item" id="item-{{ question.uuid }}-{{itemUuid}}" data-path="{{itemPath}}">
         <div class="followups">
-          {% for question in question.followups %}
+          {% for subQuestion in question.followups %}
             {% set x = loop.index %}
-            {{ renderQuestion(question, itemPath, itemHumanIdentifier ~ "." ~ x) }}
+            {{ renderQuestion(subQuestion, itemPath, itemHumanIdentifier ~ "." ~ x) }}
           {% else %}
-            <i>No follow up questions</i>
+            No follow up questions
           {% endfor %}
         </div>
       </div>
     {% else %}
-      <i>No answer items</i>
+      No answer items
     {% endfor %}
-  </div>
+  {% endif %}
+</div>
 {%- endmacro -%}
 {%- macro renderAnswerChoiceList(question, reply, path, humanIdentifier) -%}
-  <div>
-    <ul>
-    {% for choice in question.choices %}
-      {%- if choice in reply.choices %}
-        <li>✔️ {{ choice.label }}</li>
-      {%- else %}
-        <li>❌ {{ choice.label }}</li>
-      {%- endif %}
-    {% endfor %}
-    </ul>
-  </div>
+<div class="answer-block answer-items" id="{{path}}" data-path="{{path}}" data-type="answer">
+  <p class="answer">
+    {%- set chosen = [] -%}
+    {%- for choice in question.choices -%}
+      {%- if choice in reply.choices -%}
+        {%- do chosen.append(choice.label) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {% if chosen|length > 0 %}
+      <span>{{ chosen | join(", ") }}</span>
+    {% else %}
+      <span class="no-answer">No choices selected</span>
+    {% endif %}
+  </p>
+</div>
 {%- endmacro -%}
 {%- macro renderAnswerItemSelect(question, reply, path, humanIdentifier) -%}
   <div>


### PR DESCRIPTION
More compact display of list items and choice lists

-  `renderAnswerChoiceList` replaced checkbox-per-line rendering with a simple comma-separated list of only the selected choices, across all four templates.

-  `renderAnswerList` added a table view (HTML table, Markdown pipe table, or LaTeX tabular) when a list question has fewer than 6 sub-questions, with items as rows and sub-questions as columns; falls back to the original stacked layout otherwise.

